### PR TITLE
Support for Data in swift by using `make_unibyte_string` after emacs28

### DIFF
--- a/Source/Swift/Conversion.swift
+++ b/Source/Swift/Conversion.swift
@@ -74,6 +74,9 @@ extension String: EmacsConvertible {
   }
 }
 
+/// Data conversions to and from Emacs values.
+///
+/// Convert to Emacs string, this function is available after emacs 28.
 extension Data: EmacsConvertible {
   public func convert(within env: Environment) throws -> EmacsValue {
     return try env.make(self)
@@ -291,7 +294,10 @@ extension Environment {
       from: try check(pointee.make_user_ptr(raw, finalizer, value)))
   }
   func make(_ from: Data) throws -> EmacsValue {
-    try from.withUnsafeBytes { rawBufferPointer in
+    if self.version < EmacsVersion.Emacs28 {
+      throw EmacsError.unsupported(what: "make_unibyte_string is supporting from emacs28")
+    }
+    return try from.withUnsafeBytes { rawBufferPointer in
       EmacsValue(from: try check(pointee.make_unibyte_string(raw, rawBufferPointer.baseAddress, from.count)))
     }
   }

--- a/test/TestModule/Test.swift
+++ b/test/TestModule/Test.swift
@@ -1,4 +1,5 @@
 import EmacsSwiftModule
+import Foundation
 
 struct MyError: Error {
   let x: Int
@@ -31,6 +32,7 @@ class TestModule: Module {
     try env.defun("swift-float") { (arg: Double) in arg * 2 }
     try env.defun("swift-bool") { (arg: Bool) in !arg }
     try env.defun("swift-string") { (arg: String) in arg }
+    try env.defun("swift-data") { (arg: Data) in arg }
     try env.defun("swift-call") {
       (env: Environment, arg: String) throws in
       return try env.funcall("format", with: "'%s'", arg)

--- a/test/swift-module-test.el
+++ b/test/swift-module-test.el
@@ -22,6 +22,11 @@
     (should (string= s1 (swift-string s1)))
     (should (string= s2 (swift-string s2)))))
 
+(ert-deftest swift-module:check-data-conversion ()
+  :tags '(emacs-28 emacs-29 emacs-30)
+  (let ((d1 "\000\000\000\001\000"))
+    (should (string= d1 (swift-data d1)))))
+
 (ert-deftest swift-module:check-incorrect-num-of-args ()
   :tags '(emacs-all)
   (should-error (swift-int) :type 'wrong-number-of-arguments)

--- a/test/swift-module-test.el
+++ b/test/swift-module-test.el
@@ -24,8 +24,10 @@
 
 (ert-deftest swift-module:check-data-conversion ()
   :tags '(emacs-28 emacs-29 emacs-30)
-  (let ((d1 "\000\000\000\001\000"))
-    (should (string= d1 (swift-data d1)))))
+  (let ((d1 "\000\000\000\001\000")
+        (d2 ""))
+    (should (string= d1 (swift-data d1)))
+    (should (string= d2 (swift-data d2)))))
 
 (ert-deftest swift-module:check-incorrect-num-of-args ()
   :tags '(emacs-all)


### PR DESCRIPTION
I used the `make_unibyte_string` to convert bytes from code to emacs string value.
However, I found in `emacs-swift-module`, it is not supported with bytes conversion.

I add the conversion of Swift Data (aka NSData in objc) with using `make_unibyte_string`

Still, I am not sure how to do the unit test for this project.